### PR TITLE
submitが複数ある場合に、すべてのsubmitの値が送信されてしまうのは良くない

### DIFF
--- a/lib/cheerio-extend.js
+++ b/lib/cheerio-extend.js
@@ -106,6 +106,9 @@ module.exports = function (encoding, client) {
       if (! name) {
         return;
       }
+      if(type == 'submit') {
+        return;
+      }
       formParam[name] = formParam[name] || [];
       if (/(checkbox|radio)/i.test(type) && ! $(this).attr('checked')) {
         return;


### PR DESCRIPTION
現状では、以下のように書かれた場合に、editとdeleteの両方のname, valueがサーバに送信されます。
```
<input type="submit" name="edit" value="編集"/>
<input type="submit" name="delete" value="削除"/>
```
私が試したところでは、submitはボタンが押された方のinputのnameとvalueしかサーバに
送信されないようです。実際、上の例では押すボタンによって、editかdeleteのどちらかしか
サーバに到達しませんでした。

私がスクレイピングしたいサイトでは、どうやら、この仕組みを使って、押したボタンを
サーバでわかるようにしているようで、今の実装だといつでも編集をすることになってしまい、
ちょっと困ってしまいました。

もし可能であれば、この修正を受け入れてください。