### PR TITLE
submit時、input要素にvalue属性が無いとパラメータにundefinedが入るのを修正

### DIFF
--- a/lib/cheerio-extend.js
+++ b/lib/cheerio-extend.js
@@ -138,7 +138,7 @@ module.exports = function (encoding, client) {
       var fp = formParam[p];
       var pstr = '';
       for (var i = 0; i < fp.length; i++) {
-        var escval = encoding.escape(doc.encoding, fp[i]);
+        var escval = encoding.escape(doc.encoding, fp[i] != null ? fp[i] : '');
         formParamStr += '&' + p + '=' + escval;
       }
     });

--- a/test/cheerio.js
+++ b/test/cheerio.js
@@ -232,6 +232,21 @@ describe('cheerio:submit', function () {
     });
   });
 
+  it('input要素のvalueがない場合空文字となる', function (done) {
+    cli.fetch(helper.url('form', 'utf-8'), function (err, $, res, body) {
+      $('form[name=no-input-value]').submit(function (err, $, res, body) {
+        assert($.documentInfo().url === helper.url('~info'));
+        var h = res.headers;
+        assert(h['request-url'] === '/~info');
+        assert(h['request-method'] === 'POST');
+        assert(h['post-data'] === 'hoge=');
+        assert(type($) === 'function');
+        assert(type(body) === 'string');
+        done();
+      });
+    });
+  });
+
   it('submit()時に指定するパラメータのvalueがnull/undefined/emptyの場合は"name="という形でURLに追加される', function (done) {
     cli.fetch(helper.url('form', 'utf-8'), function (err, $, res, body) {
       $('form[name=post]').submit({

--- a/test/fixtures/form/utf-8.html
+++ b/test/fixtures/form/utf-8.html
@@ -85,6 +85,10 @@
       <input type="submit">
     </form>
 
+    <form name="no-input-value" action="/~info" method="POST">
+      <input type="text" name="hoge">
+    </form>
+
     <form name="nothing"></form>
 
     <form name="default-jp" action="/~info" method="POST">


### PR DESCRIPTION
`value`属性のない`input`要素のあるフォームを送信しようとしたとき、意図せず`"undefined"`という文字列が入る不具合に遭遇しましたので修正しました
