### PR TITLE
受信を許可する最大のサイズを指定できるように

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -123,8 +123,13 @@ module.exports = {
       process.stderr.write(prettyjson.render(debugParams) + '\n\n');
     }
 
+    // レスポンスのサイズを計測するためのバッファ
+    var buffer = '';
+
+    var maxDataSize = this.core.maxDataSize;
+
     // リクエスト実行
-    request(param, (function (err, res, body) {
+    var req = request(param, (function (err, res, body) {
       if (err) {
         return callback(err, res, body);
       }
@@ -161,7 +166,18 @@ module.exports = {
       } else {
         return callback(undefined, res, body);
       }
-    }).bind(this));
+    }).bind(this)).on('data', function(chunk) {
+      if (maxDataSize !== null) {
+        // バッファにチャンクを追加
+        buffer += chunk;
+
+        // 制限を超過したら中止
+        if (buffer.length > maxDataSize) {
+          req.abort();
+          return callback(new Error('data size limit over'));
+        }
+      }
+    });
   },
 
   /**

--- a/lib/core.js
+++ b/lib/core.js
@@ -21,6 +21,7 @@ var cheerioHttpCli = {
   gzip    : true,        // gzip転送する/しない
   referer : true,        // Refererを自動設定する/しない
   debug   : false,       // デバッグオプション
+  maxDataSize : null,    // 受信を許可する最大のサイズ
 
   /**
    * メソッド


### PR DESCRIPTION
ユーザーから入力されたURLを解析する場合などにおいて、不用意に大きいデータを読み込んでしまい回線を占有するようなことが起きないように

デフォルトでこのオプションは``null``で、従来のように制限無しです