### PR TITLE
HTMLエンティティデコードはclient.loadOptionsで指定できるようにする

### DIFF
--- a/lib/cheerio-extend.js
+++ b/lib/cheerio-extend.js
@@ -5,41 +5,11 @@ var cheerio   = require('cheerio');
 var util      = require('util');
 var assert    = require('assert');
 var urlParser = require('url');
-var ent       = require('ent');
 
 /**
  * cheerioオブジェクト拡張モジュール(プロトタイプにメソッド追加)
  */
 module.exports = function (encoding, client) {
-  /**
-   * cheerioデフォルトのtext(), html()メソッドはエンティティ表記をそのまま返すので
-   * 上記メソッドを拡張してエンティティもデコードした状態で返すようにする
-   *
-   * @param str 指定した場合はその文字列を要素のテキスト(HTML)として設定
-   *            指定しない場合は要素に設定されているテキスト(HTML)を返す
-   */
-  // cheerioデフォルトのメソッドを'_'付きで退避
-  cheerio.prototype._text = cheerio.prototype.text;
-  cheerio.prototype._html = cheerio.prototype.html;
-
-  var decodeEntities = function (str) {
-    // 文字列でない場合(cheerioオブジェクトなど)はそのまま返す
-    if (typeof str !== 'string') {
-      return str;
-    }
-    return ent.decode(str);
-  };
-
-  cheerio.prototype.text = function (str) {
-    // cheerioデフォルトのtext()結果をデコード(エンティティ可読文字化)したものを返す
-    return decodeEntities(this._text(str));
-  };
-
-  cheerio.prototype.html = function (str) {
-    // cheerioデフォルトのhtml()結果をデコード(エンティティ可読文字化)したものを返す
-    return decodeEntities(this._html(str));
-  };
-
   /**
    * a要素のリンクのクリックをエミュレート(リンク先のページを取得)
    *

--- a/lib/client.js
+++ b/lib/client.js
@@ -223,7 +223,7 @@ module.exports = {
       result.body = body.toString('utf8');
 
       // cheerioでHTMLコンテンツをパース & 現在のページ情報を追加
-      result.$ = this.cheerio.load(result.body, { decodeEntities: false });
+      result.$ = this.cheerio.load(result.body, this.core.loadOptions);
       result.$._root._documentInfo = {
         url: res.request.uri.href,
         encoding: enc

--- a/lib/core.js
+++ b/lib/core.js
@@ -22,6 +22,7 @@ var cheerioHttpCli = {
   referer : true,        // Refererを自動設定する/しない
   debug   : false,       // デバッグオプション
   maxDataSize : null,    // 受信を許可する最大のサイズ
+  loadOptions: {decodeEntities: true}, //cheerio.loadに渡すオプション
 
   /**
    * メソッド

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "cheerio": "^0.19.0",
-    "ent": "^2.2.0",
     "iconv-lite": "^0.4.13",
     "jschardet": "^1.3.0",
     "prettyjson": "^1.1.3",


### PR DESCRIPTION
今まで、cheerio.loadに `{ decodeEntities: false }` をわたし、cheerio.prototype.{text, html}でHTMLエンティティをデコードしていたため、cheerio.prototype.{attr,data}などではHTMLエンティティがデコードされていませんでした。

このPRでは、 `client.loadOptions` を追加し、初期値を `{ decodeEntities: true }` として、これを `cheerio.load` に渡すようにしたため、cheerioの全メソッドでデコード済みの値が取得できるようになり、独自の {text, html} プロトタイプ拡張が不要になります。

マージよろしくお願いします！