### PR TITLE
POST後のリダイレクトで相対パスが渡された時に絶対パス化する

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -138,7 +138,7 @@ module.exports = {
   checkRedirect: function (res, body) {
     // POST後のリダイレクトはrequestモジュールでは自動で飛んでくれない(と思う)
     if (/^30\d$/.test(res.statusCode) && res.headers.location) {
-      return res.headers.location;
+      return urlParser.resolve(res.request.uri.href, res.headers.location);
     }
 
     // ここから先はHTMLの場合のみ


### PR DESCRIPTION
POSTリクエスト後に相対パスでリダイレクト先が渡された際に，Invalid URI 例外が生じていたため絶対パス化処理を追加しました．