### PR TITLE
型定義を更新

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,16 @@ declare namespace CheerioHttpcli {
   interface FetchResponse extends http.IncomingMessage {
     cookies: {[ name: string ]: string};
   }
+
+  // CheerioStatic拡張
+  interface CheerioStaticEx extends CheerioStatic {
+    documentInfo(): { url: string, encoding: string | null, isXml: boolean };
+    entityHtml(options?: CheerioOptionsInterface): string;
+    entityHtml(selector: string, options?: CheerioOptionsInterface): string;
+    entityHtml(element: Cheerio, options?: CheerioOptionsInterface): string;
+    entityHtml(element: CheerioElement, options?: CheerioOptionsInterface): string;
+  }
+
   interface FetchResult {
     error: Error;
     $: CheerioStaticEx;
@@ -74,15 +84,6 @@ declare namespace CheerioHttpcli {
   function fetchSync(url: string, param: {[ name: string ]: any}): FetchResult;
   function fetchSync(url: string, encode: string): FetchResult;
   function fetchSync(url: string): FetchResult;
-}
-
-// cheerio本体拡張(オリジナルのinterfaceを継承)
-interface CheerioStaticEx extends CheerioStatic {
-  documentInfo(): { url: string, encoding: string | null, isXml: boolean };
-  entityHtml(options?: CheerioOptionsInterface): string;
-  entityHtml(selector: string, options?: CheerioOptionsInterface): string;
-  entityHtml(element: Cheerio, options?: CheerioOptionsInterface): string;
-  entityHtml(element: CheerioElement, options?: CheerioOptionsInterface): string;
 }
 
 // cheerio拡張メソッド(オリジナルのinterfaceにマージ)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import * as http from 'http';
 import * as url from 'url';
 import * as stream from 'stream';
+import 'cheerio';
 
 // cheerio-httpcli本体
 declare namespace CheerioHttpcli {


### PR DESCRIPTION
- コンパイル時にcheerioをextendsしている部分で必ずエラーが発生していたのでimportを追加しました
- CheerioStaticExが外から一切見えなく、個別で参照することができなく困ったため見えるようにしました
以下のようなラッパーが作れるようになります
```typescript
import * as client from "cheerio-httpcli";

/**
 * wrapper of cheerio-httpcli. fetch html.
 * @param	{string}	url	request url
 * @returns	{Promise<client.CheerioStaticEx>}	object extends CheerioStatic
 */
const wrapper = async (url: string): Promise<client.CheerioStaticEx> => {
	const result = await client.fetch(url);
	const type: string = result.response.headers['content-type'];

	/* rejects */
	if (result.error !== undefined && result.error !== null) throw "happend-error";
	if (! /text\/html/.test(type)) throw "not-html";

	/* resolve result */
	return result.$;
};

wrapper('https://github.com/prezzemolo').then(result => {
	console.dir(result);
});
```