### PR TITLE
a,img要素だけでなくscript,link要素のURLも絶対パスで取得できるように実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Node.jsでWEBページのスクレイピングを行う際に必要となる文�
 4. Node.jsお馴染みのコールバック形式と最近の流行であるプロミス形式どちらにも対応
 5. 同期リクエスト対応
 6. `$('img')`要素画像のダウンロード(LazyLoad対応)
-7. `$('a,img')`要素のURLを絶対パスで取得可能
+7. `$('a,img,script,link')`要素のURLを絶対パスで取得可能
 8. ブラウザ指定による簡単User-Agent切り替え機能
 9. 現在のクッキーの内容を簡単に取得(読み取り専用)
 10. XMLドキュメントを自動判別してパース処理を切り替え
@@ -781,7 +781,7 @@ $('input[type=radio]').untick();              // => 全ラジオボタンを非�
 
 ### $(_link-element_ or _image-element_).url([ filter, src-attr ])
 
-`a`要素の`href`、もしくは`img`要素の`src`のURLを完全な形(絶対パス)にしたものを取得します。元から完全なURLになっている場合(外部リンクなど)や`javascript:void(0)`といったURLでないリンクはその内容をそのまま返します。
+`a`要素の`href`、`img`要素の`src`、`script`要素の`src`、もしくは`link`要素の`href`のURLを完全な形(絶対パス)にしたものを取得します。元から完全なURLになっている場合(外部リンクなど)や`javascript:void(0)`といったURLでないリンクはその内容をそのまま返します。
 
 ```html
 <a id="top" href="../index.html">トップページ</a>

--- a/lib/cheerio/url.js
+++ b/lib/cheerio/url.js
@@ -11,7 +11,7 @@ var assign    = require('object-assign');
 
 module.exports = function (encoding, client, cheerio) {
   /**
-   * a要素/img要素の絶対URLを取得
+   * a要素/img要素/script要素/link要素の絶対URLを取得
    *
    * @param optFilter 取得するURLのフィルタリングオプション
    * @param srcAttrs  (imgのみ)srcよりも優先して取得する属性名(文字列 or 配列)
@@ -41,21 +41,25 @@ module.exports = function (encoding, client, cheerio) {
     }
     srcAttrs.push('src');
 
-    // a要素/img要素でなければエラー
+    // a要素/img要素/script要素でなければエラー
     this.each(function () {
       var $elem = $(this);
       var is = {
         a: $elem.is('a'),
-        img: $elem.is('img')
+        img: $elem.is('img'),
+        script: $elem.is('script'),
+        link: $elem.is('link')
       };
-      if (! is.a && ! is.img) {
-        throw new Error('element is not link or img');
+      if (! is.a && ! is.img && ! is.script && ! is.link) {
+        throw new Error('element is not link, img, script or link');
       }
 
       // URLを取り出して絶対化
       var srcUrl = null;
-      if (is.a) {
+      if (is.a || is.link) {
         srcUrl = $elem.attr('href');
+      } else if (is.script) {
+        srcUrl = $elem.attr('src');
       } else {
         // imgの場合はsrcAttrsの優先順に従って属性を見ていく
         for (var i = 0; i < srcAttrs.length; i++) {

--- a/test/cheerio-url.js
+++ b/test/cheerio-url.js
@@ -26,7 +26,7 @@ describe('cheerio:url', function () {
             $(elem).eq(0).url();
             throw new Error('not thrown');
           } catch (e) {
-            assert(e.message === 'element is not link or img');
+            assert(e.message === 'element is not link, img, script or link');
           }
           done();
         });
@@ -450,6 +450,74 @@ describe('cheerio:url', function () {
           'http://www.google.co.jp/'
         ];
         var actual = $('img, a').url({ relative: false, invalid: false });
+        assert.deepEqual(actual, expected);
+        done();
+      });
+    });
+  });
+
+  describe('script要素', function () {
+    it('単一要素 => srcに指定したURLを絶対URLにして返す', function (done) {
+      cli.fetch(helper.url('script', 'index'), function (err, $, res, body) {
+        var expected = helper.url('script', 'js/cat').replace(/\.html/, '.js');
+        var actual = $('.rel').url();
+        assert(actual === expected);
+        done();
+      });
+    });
+
+    it('単一のインラインでJavaScriptが書かれているscript要素 => srcには何も指定がないのでundefinedで返す', function (done) {
+      cli.fetch(helper.url('script', 'index'), function (err, $, res, body) {
+        var actual = $('.inline').url();
+        assert(typeOf(actual) === 'undefined');
+        done();
+      });
+    });
+
+    it('複数要素 => 各要素のsrcのURLを絶対URLにした配列を返す', function (done) {
+      cli.fetch(helper.url('script', 'index'), function (err, $, res, body) {
+        var base = helper.url('script');
+        var expected = [
+          base + '/js/cat.js',
+          undefined,
+          '',
+          base + '/js/food.js?hoge=fuga&piyo=',
+          'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js',
+          base + '/not-found.js',
+          undefined,
+          base + '/js/dog.js'
+        ];
+        var actual = $('script').url([]);
+        assert.deepEqual(actual, expected);
+        done();
+      });
+    });
+  });
+
+  describe('link要素', function () {
+    it('単一要素 => hrefに指定したURLを絶対URLにして返す', function (done) {
+      cli.fetch(helper.url('link', 'index'), function (err, $, res, body) {
+        var expected = helper.url('link', 'css/cat').replace(/\.html/, '.css');
+        var actual = $('.rel').url();
+        assert(actual === expected);
+        done();
+      });
+    });
+
+    it('複数要素 => 各要素のhrefのURLを絶対URLにした配列を返す', function (done) {
+      cli.fetch(helper.url('link', 'index'), function (err, $, res, body) {
+        var base = helper.url('link');
+        var expected = [
+          base + '/css/cat.css',
+          undefined,
+          '',
+          base + '/css/food.css?hoge=fuga&piyo=',
+          'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
+          base + '/not-found.css',
+          base + '/en.html',
+          base + '/css/dog.css'
+        ];
+        var actual = $('link').url([]);
         assert.deepEqual(actual, expected);
         done();
       });

--- a/test/fixtures/link/css/cat.css
+++ b/test/fixtures/link/css/cat.css
@@ -1,0 +1,3 @@
+a {
+    font-weight: bold;
+}

--- a/test/fixtures/link/css/dog.css
+++ b/test/fixtures/link/css/dog.css
@@ -1,0 +1,3 @@
+a {
+    font-size: large;
+}

--- a/test/fixtures/link/en.html
+++ b/test/fixtures/link/en.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html lang="en">
+</html>

--- a/test/fixtures/link/index.html
+++ b/test/fixtures/link/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <title>linkタグテスト</title>
+    <link class="rel" rel="stylesheet" type="text/css" href="./css/cat.css">
+    <link class="undef" rel="stylesheet" type="text/css">
+    <link class="empty" rel="stylesheet" type="text/css" href="">
+    <link class="root" rel="stylesheet" type="text/css" href="/link/css/food.css?hoge=fuga&piyo=">
+    <link class="external" rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <link class="err404" rel="stylesheet" type="text/css" href="./not-found.css">
+    <link class="notcss" rel="alternate" hreflang="en" type="text/html" href="./en.html">
+  </head>
+  <body>
+    <div>
+      <link class="body" rel="stylesheet" type="text/css" href="./css/dog.css">
+    </div>
+
+    <a href="http://www.google.co.jp/">google</a>
+    <a href="/~info?foo=1&bar=2&baz=3">~info</a>
+  </body>
+</html>

--- a/test/fixtures/script/index.html
+++ b/test/fixtures/script/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <title>scriptタグテスト</title>
+    <script class="rel" src="./js/cat.js"></script>
+    <script class="undef"></script>
+    <script class="empty" src=""></script>
+    <script class="root" src="/script/js/food.js?hoge=fuga&piyo="></script>
+    <script class="external" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script class="err404" src="./not-found.js"></script>
+    <script class="inline">
+      var animal = 'dog';
+    </script>
+  </head>
+  <body>
+    <div>
+      <script class="body" src="./js/dog.js"></script>
+    </div>
+
+    <a href="http://www.google.co.jp/">google</a>
+    <a href="/~info?foo=1&bar=2&baz=3">~info</a>
+  </body>
+</html>

--- a/test/fixtures/script/js/cat.js
+++ b/test/fixtures/script/js/cat.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function () {
+  var cat = 'cat';
+  return cat;
+};
+

--- a/test/fixtures/script/js/dog.js
+++ b/test/fixtures/script/js/dog.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function () {
+  var dog = 'dog';
+  return dog;
+};

--- a/test/fixtures/script/js/food.js
+++ b/test/fixtures/script/js/food.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function () {
+  var food = 'food';
+  return food;
+};
+


### PR DESCRIPTION
cheerio.url()の拡張を実施しています

Fix #21 