### PR TITLE
Download.Managerがメソッドチェーンできるように型定義ファイルを修正

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ declare namespace CheerioHttpcli {
       parallel: number;
       state: { queue: number, complete: number, error: number };
       clearCache(): void;
-      on(events: string, handler: ((stream: Stream) => void) | ((error: ErrorEx) => void) | (() => void)): void;
+      on(events: string, handler: ((stream: Stream) => void) | ((error: ErrorEx) => void) | (() => void)): Manager;
     }
   }
 


### PR DESCRIPTION
TypeScriptで `client.download.on().on()` とメソッドチェーンができなかったので、型定義ファイルを修正しました。