### PR TITLE
fix: pin colors@1.4.0 to fix security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/rsvp": "^4.0.4",
     "async": "^3.2.0",
     "cheerio": "^0.22.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "foreach": "^2.0.5",
     "he": "^1.2.0",
     "iconv-lite": "^0.6.3",


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR pins the color package to `1.4.0` as advised on the [snyk page](https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/)